### PR TITLE
Add variables to terminal, and quote enclosed string support

### DIFF
--- a/addons/terminal/terminal.gd
+++ b/addons/terminal/terminal.gd
@@ -12,10 +12,30 @@ var settings : Dictionary = {
 	
 }
 
+var variables = {
+	"camid": func(): return str(get_viewport().get_camera_3d().get_instance_id()),
+}
+
 func run_command(command : String):
 	add_to_log("> " + command)
+	
 	var split_command :	Array
-	split_command = command.split(" ")
+	var regex_split = RegEx.new()
+	regex_split.compile("[^\\s\"']+|\"([^\"]*)\"|'([^']*)'")
+	split_command = regex_split.search_all(command).map(func(x): return x.get_string().rstrip("\"").lstrip("\""))
+	#Replace variables
+	for s_command_index : int in len(split_command):
+		var s_command = split_command[s_command_index]
+		if(s_command.begins_with("$")):
+			print("starts_with $")
+			var variable = variables.get(s_command.lstrip("$"), s_command)
+			print(variable)
+			if(variable is Callable):
+				s_command = str(variable.call())
+			else:
+				s_command = str(variable)
+		split_command[s_command_index] = s_command
+				
 	if(split_command.size() > 0):
 		var application = split_command[0]
 		var params = split_command.slice(1,split_command.size())
@@ -38,6 +58,12 @@ func find_application(application_id):
 		return load(path+application_id+".gd").new()
 	else:
 		return null
+
+func set_variable(key : String, value : Variant):
+	variables[key] = value
+	
+func get_variable(key : String):
+	variables.get(key)
 
 func add_to_log(statement: String):
 	log.push_back(statement)


### PR DESCRIPTION
Adds a dictionary of variables that can be replaced by using the syntax $variable and will be replaced by the value in the dictionary

Adds support for parameters with spaces as long as they are quote enclosed.